### PR TITLE
Converting TextMapReader callback to functor

### DIFF
--- a/opentracing/tracer.cc
+++ b/opentracing/tracer.cc
@@ -58,6 +58,10 @@ TextMapReader::~TextMapReader()
 {
 }
 
+TextMapReader::ReadCallback::~ReadCallback()
+{
+}
+
 namespace {
 
 class NoopSpan : public virtual Span

--- a/opentracing/tracer.h
+++ b/opentracing/tracer.h
@@ -247,12 +247,16 @@ public:
     /**
      * The type of callback which will be called for each key.
      */
-    typedef void (*PairReadCallback)(const std::string& key, const std::string& value, bool isBaggage);
+    struct ReadCallback
+    {
+        virtual ~ReadCallback();
+        virtual void read(const std::string& key, const std::string& value, bool isBaggage) = 0;
+    };
 
     /**
      * Reads from the carrier and calls the `callback()` for each key-value pair.
      */
-    virtual void forEachPair(const PairReadCallback & callback) const = 0;
+    virtual void forEachPair(const ReadCallback & callback) const = 0;
 };
 
 /**

--- a/opentracing/tracer.h
+++ b/opentracing/tracer.h
@@ -245,12 +245,20 @@ public:
     virtual ~TextMapReader();
 
     /**
-     * The type of callback which will be called for each key.
+     * Callback functor typically implemented from the tracer in order to retrieve
+     * key-value pairs from the `TextMapReader`.
      */
     struct ReadCallback
     {
+        /**
+         *  Destroys this ReadCallback.
+         */
         virtual ~ReadCallback();
-        virtual void operator() (const std::string& key, const std::string& value, bool isBaggage) = 0;
+
+        /**
+         *  Will be called for each key-value pair.
+         */
+        virtual void operator() (const std::string& key, const std::string& value, bool isBaggage) const = 0;
     };
 
     /**

--- a/opentracing/tracer.h
+++ b/opentracing/tracer.h
@@ -250,7 +250,7 @@ public:
     struct ReadCallback
     {
         virtual ~ReadCallback();
-        virtual void read(const std::string& key, const std::string& value, bool isBaggage) = 0;
+        virtual void operator() (const std::string& key, const std::string& value, bool isBaggage) = 0;
     };
 
     /**

--- a/test/opentracing.t.cc
+++ b/test/opentracing.t.cc
@@ -158,7 +158,7 @@ public:
         m_carrier.insert(typename T::value_type(key, std::make_pair(value, isBaggage)));
     }
 
-    virtual void forEachPair(const PairReadCallback & callback) const
+    virtual void forEachPair(const ReadCallback & callback) const
     {
         for (typename T::const_iterator i = m_carrier.begin(); i != m_carrier.end(); ++i)
         {


### PR DESCRIPTION
Converting TextMapReader callback to functor. Makes implementations much nicer.