### PR TITLE
Adding a way to print span/trace ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ make
 ./test
 ```
 
+Note - You might have to set your `LD_LIBRARY_PATH`:
+
+```
+LD_LIBRARY_PATH=/usr/local/lib ./test
+```
+
 ## API overview for those adding instrumentation
 
 Everyday consumers of this `opentracing` package really only need to worry

--- a/opentracing/span.h
+++ b/opentracing/span.h
@@ -102,6 +102,13 @@ public:
     virtual const Tracer & getTracer() const = 0;
 
     /**
+     * Prints minimal information able to identify the span (e.g. trace id/span id) to an
+     * output stream. This is useful in order to be able to corellate traces with other
+     * types of logs.
+     */
+    virtual std::ostream & print(std::ostream & os) const = 0;
+
+    /**
      * Stops this span. `finish()` should be the last call made to any span instance,
      * and to do otherwise leads to undefined behavior.
      */

--- a/opentracing/tracer.cc
+++ b/opentracing/tracer.cc
@@ -82,6 +82,11 @@ public:
         return m_noopTracer;
     }
 
+    virtual std::ostream & print(std::ostream & os) const
+    {
+        return os << "NoopSpan: N/A";
+    }
+
 private:
 
     const NoopTracer & m_noopTracer;

--- a/test/opentracing.t.cc
+++ b/test/opentracing.t.cc
@@ -115,6 +115,12 @@ TEST(opentracing, span_ops)
     ASSERT_FALSE(span->getBaggageItem("key2"));
     ASSERT_FALSE(span->getBaggageItem("key3", &target));
 
+    // One can print trace identifiers by using the `print()` method.
+    std::ostringstream oss;
+    span->print(oss);
+    ASSERT_EQ("NoopSpan: N/A", oss.str());
+
+
     // Exercise getTracer()
     ASSERT_EQ(&span->getTracer(), globalTracer());
 


### PR DESCRIPTION
Adding a method that prints minimal information able to identify the span (e.g. trace id/span id) to an output stream. This is useful in order to be able to correlate traces with other types of logs.