### PR TITLE
keep gcc specific flags specific to a gcc build

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,9 @@ libopentracing_la_LDFLAGS = -version-info 1:0:0
 
 ACLOCAL_AMFLAGS = -I m4
 
-AM_CXXFLAGS=  -Wall -fno-elide-constructors -pedantic-errors -ansi -Wextra -Wall
-AM_CXXFLAGS+= -Winit-self -Wold-style-cast -Woverloaded-virtual -Winit-self
-AM_CXXFLAGS+= -Wuninitialized -Wmissing-declarations -Werror -std=c++98
+AM_CXXFLAGS=  -fno-elide-constructors -pedantic-errors -ansi -std=c++98
+
+if COMPILER_IS_GCC
+AM_CXXFLAGS+= -Wall -Werror -Wextra -Winit-self -Wold-style-cast 
+AM_CXXFLAGS+= -Woverloaded-virtual -Wuninitialized -Wmissing-declarations 
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -3,6 +3,8 @@ AC_INIT([libopentracing], [1.0.0])
 #AM_INIT_AUTOMAKE([-Wall -Werror foreign])
 AM_INIT_AUTOMAKE([subdir-objects])
 
+AM_CONDITIONAL(COMPILER_IS_GCC, test "x$GCC" = "xyes")
+
 AC_CONFIG_MACRO_DIR([m4])
 
 #AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
Adds a COMPILER_IS_GCC flag in the configure.ac, which can then be read in Makefile.am. Then restrict the gcc specific flags to when gcc is the compiler. With this in place we can build on AIX and Solaris