### PR TITLE
Work around compilation issue on OS X.

### DIFF
--- a/c++11/test/util_test.cpp
+++ b/c++11/test/util_test.cpp
@@ -1,6 +1,7 @@
 #include <opentracing/util.h>
 #include <cassert>
 #include <cmath>
+#include <cstdlib>  // Work around to https://stackoverflow.com/a/30084734.
 using namespace opentracing;
 
 static void test_convert_time_point() {


### PR DESCRIPTION
Puts in a fix for this [problem](https://stackoverflow.com/questions/30084577/ambiguous-call-to-abs) on OS X.