### PR TITLE
Store tags in StartSpanOptions as string. Correct comment.

### DIFF
--- a/include/opentracing/tracer.h
+++ b/include/opentracing/tracer.h
@@ -63,12 +63,12 @@ class Tracer {
   //     // The vanilla child span case:
   //     auto span = tracer.StartSpan(
   //         "GetFeed",
-  //         {opentracing::ChildOf(parentSpan.context())})
+  //         {opentracing::ChildOf(&parentSpan.context())})
   //
   //     // All the bells and whistles:
   //     auto span = tracer.StartSpan(
   //         "GetFeed",
-  //         {opentracing::ChildOf(parentSpan.context()),
+  //         {opentracing::ChildOf(&parentSpan.context()),
   //         opentracing::Tag{"user_agent", loggedReq.UserAgent},
   //         opentracing::StartTimestamp(loggedReq.timestamp())})
   //

--- a/include/opentracing/tracer.h
+++ b/include/opentracing/tracer.h
@@ -25,7 +25,7 @@ struct StartSpanOptions {
   SystemTime start_system_timestamp;
   SteadyTime start_steady_timestamp;
   std::vector<std::pair<SpanReferenceType, const SpanContext*>> references;
-  std::vector<std::pair<string_view, Value>> tags;
+  std::vector<std::pair<std::string, Value>> tags;
 };
 
 // StartSpanOption instances (zero or more) may be passed to Tracer.StartSpan.
@@ -245,7 +245,7 @@ class SetTag : public StartSpanOption {
   }
 
  private:
-  string_view key_;
+  const string_view key_;
   const Value& value_;
 };
 END_OPENTRACING_ABI_NAMESPACE


### PR DESCRIPTION
This change should reduce the chance of dangling pointers in a number of scenarios. It also allows for moving the tags from the StartSpanOptions directly into the span, which is probably a common use case when constructing a span. I did do a small test and this was faster because of allowing move semantics. It would also be possible to use move semantics in the construction of StartSpanOption implementations which might further further improve performance.

Corrects a comment which gives an example of use.
