### PR TITLE
Support key lookup in span context extraction.

### DIFF
--- a/include/opentracing/value.h
+++ b/include/opentracing/value.h
@@ -37,15 +37,13 @@ class Value : public variant_type {
                                     std::is_signed<T>::value>::type* = nullptr>
   Value(T t) noexcept : variant_type(static_cast<int64_t>(t)) {}
 
-  template <
-      typename T,
-      typename std::enable_if<std::is_integral<T>::value &&
-                              std::is_unsigned<T>::value>::type* = nullptr>
+  template <typename T, typename std::enable_if<
+                            std::is_integral<T>::value &&
+                            std::is_unsigned<T>::value>::type* = nullptr>
   Value(T t) noexcept : variant_type(static_cast<uint64_t>(t)) {}
 
-  template <typename T,
-            typename std::enable_if<std::is_floating_point<T>::value>::type* =
-                nullptr>
+  template <typename T, typename std::enable_if<
+                            std::is_floating_point<T>::value>::type* = nullptr>
   Value(T t) noexcept : variant_type(static_cast<double>(t)) {}
 
   Value(const char* s) noexcept : variant_type(s) {}

--- a/include/opentracing/value.h
+++ b/include/opentracing/value.h
@@ -37,13 +37,15 @@ class Value : public variant_type {
                                     std::is_signed<T>::value>::type* = nullptr>
   Value(T t) noexcept : variant_type(static_cast<int64_t>(t)) {}
 
-  template <typename T, typename std::enable_if<
-                            std::is_integral<T>::value &&
-                            std::is_unsigned<T>::value>::type* = nullptr>
+  template <
+      typename T,
+      typename std::enable_if<std::is_integral<T>::value &&
+                              std::is_unsigned<T>::value>::type* = nullptr>
   Value(T t) noexcept : variant_type(static_cast<uint64_t>(t)) {}
 
-  template <typename T, typename std::enable_if<
-                            std::is_floating_point<T>::value>::type* = nullptr>
+  template <typename T,
+            typename std::enable_if<std::is_floating_point<T>::value>::type* =
+                nullptr>
   Value(T t) noexcept : variant_type(static_cast<double>(t)) {}
 
   Value(const char* s) noexcept : variant_type(s) {}

--- a/src/propagation.cpp
+++ b/src/propagation.cpp
@@ -8,9 +8,7 @@ class PropagationErrorCategory : public std::error_category {
   // Needed to fix bug in macOS build
   // (https://travis-ci.org/isaachier/hunter/jobs/281868518).
   // See https://stackoverflow.com/a/7411708/1930331 for justification.
-  PropagationErrorCategory()
-  {
-  }
+  PropagationErrorCategory() {}
 
   const char* name() const noexcept override {
     return "OpenTracingPropagationError";
@@ -27,6 +25,12 @@ class PropagationErrorCategory : public std::error_category {
     if (code == span_context_corrupted_error.value()) {
       return std::make_error_condition(std::errc::invalid_argument);
     }
+    if (code == key_not_found_error.value()) {
+      return std::make_error_condition(std::errc::invalid_argument);
+    }
+    if (code == lookup_key_not_supported_error.value()) {
+      return std::make_error_condition(std::errc::not_supported);
+    }
     return std::error_condition(code, *this);
   }
 
@@ -39,6 +43,12 @@ class PropagationErrorCategory : public std::error_category {
     }
     if (code == span_context_corrupted_error.value()) {
       return "opentracing: SpanContext data corrupted in Extract carrier";
+    }
+    if (code == key_not_found_error.value()) {
+      return "opentracing: SpanContext key not found";
+    }
+    if (code == lookup_key_not_supported_error.value()) {
+      return "opentracing: Lookup for the given key is not supported";
     }
     return "opentracing: unknown propagation error";
   }


### PR DESCRIPTION
Some concerns have come up around the efficiency of extracting a span context. The current API forces tracer implementations to iterate and compare against all the key values in a carrier. If there’s no indexing on the keys, this is reasonable; but when there’s key indexing, it requires the tracer to do more comparisons than are necessary.

This PR adds optional support for looking up values by key. A carrier can either support lookup for all, some, or no keys; and it doesn’t break compatibility with the existing API. Tracers are still required to support extracting span context using the [ForeachKey method](https://github.com/opentracing/opentracing-cpp/blob/master/include/opentracing/propagation.h#L103), but can also take advantage of the lookup API for faster extraction if available.