### PR TITLE
Add a Bazel build file for opentracing-cpp.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,30 @@
+cc_library(
+    name = "opentracing",
+    srcs = glob(["src/*.cpp"]),
+    hdrs = glob(["include/opentracing/*.h"]) + [
+        ":include/opentracing/version.h",
+    ],
+    strip_include_prefix = "include",
+    visibility = ["//visibility:public"],
+    deps = [":3rd_party_lib"],
+)
+
+genrule(
+    name = "generate_version_h",
+    srcs = glob([
+        "*",
+        "cmake/*",
+        "src/*",
+    ]),
+    outs = ["include/opentracing/version.h"],
+    cmd = """
+    cmake -DBUILD_TESTING=OFF -L $$(dirname $(location :CMakeLists.txt))
+    mv include/opentracing/version.h $@
+    """,
+)
+
+cc_library(
+    name = "3rd_party_lib",
+    hdrs = glob(["3rd_party/include/**/*.hpp"]),
+    strip_include_prefix = "3rd_party/include",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "io_opentracing_cpp")

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,0 +1,12 @@
+TEST_NAMES = [
+    "string_view_test",
+    "tracer_test",
+    "util_test",
+    "value_test",
+]
+
+[cc_test(
+    name = test_name,
+    srcs = [test_name + ".cpp"],
+    deps = ["//:opentracing"],
+) for test_name in TEST_NAMES]


### PR DESCRIPTION
This lets projects that use the Bazel build system (http://bazel.build)
more easily depend on OpenTracing.

To generate `version.h`, the config shells out to `cmake` instead of
duplicating the existing version definitions from `CMakeLists.txt`.