### PR TITLE
Ensure that assert is not ignored for tests.

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -7,6 +7,6 @@ TEST_NAMES = [
 
 [cc_test(
     name = test_name,
-    srcs = [test_name + ".cpp"],
+    srcs = [test_name + ".cpp", "assert.h"],
     deps = ["//:opentracing"],
 ) for test_name in TEST_NAMES]

--- a/test/assert.h
+++ b/test/assert.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <iostream>
+#include <cstdlib>
+
+#define ASSERT(EXPR)                                                     \
+  do {                                                                   \
+    if (!(EXPR)) {                                                       \
+      std::cerr << "Failed in " << __FILE__ << ":" << __LINE__ << ": \"" \
+                << #EXPR "\" evaluted to false\n";                       \
+      std::exit(-1);                                                     \
+    }                                                                    \
+  } while (false);

--- a/test/string_view_test.cpp
+++ b/test/string_view_test.cpp
@@ -1,16 +1,14 @@
-// Make sure assert is defined.
-#undef NDEBUG
+#include "assert.h"
 
 #include <opentracing/string_view.h>  // test include guard
 #include <opentracing/string_view.h>
-#include <cassert>
 
 using namespace opentracing;
 
 static void test_empty() {
   string_view ref;
-  assert(0 == ref.data());
-  assert(0 == ref.length());
+  ASSERT(0 == ref.data());
+  ASSERT(0 == ref.length());
 }
 
 static void test_cstring() {
@@ -18,8 +16,8 @@ static void test_cstring() {
 
   string_view ref(val);
 
-  assert(val == ref.data());
-  assert(std::strlen(val) == ref.length());
+  ASSERT(val == ref.data());
+  ASSERT(std::strlen(val) == ref.length());
 }
 
 static void test_std_string() {
@@ -27,8 +25,8 @@ static void test_std_string() {
 
   string_view ref(val);
 
-  assert(val == ref.data());
-  assert(val.length() == ref.length());
+  ASSERT(val == ref.data());
+  ASSERT(val.length() == ref.length());
 }
 
 static void test_copy() {
@@ -37,8 +35,8 @@ static void test_copy() {
   string_view ref(val);
   string_view cpy(ref);
 
-  assert(val == cpy.data());
-  assert(val.length() == cpy.length());
+  ASSERT(val == cpy.data());
+  ASSERT(val.length() == cpy.length());
 }
 
 int main() {

--- a/test/string_view_test.cpp
+++ b/test/string_view_test.cpp
@@ -1,3 +1,6 @@
+// Make sure assert is defined.
+#undef NDEBUG
+
 #include <opentracing/string_view.h>  // test include guard
 #include <opentracing/string_view.h>
 #include <cassert>

--- a/test/tracer_test.cpp
+++ b/test/tracer_test.cpp
@@ -1,23 +1,21 @@
-// Make sure assert is defined.
-#undef NDEBUG
+#include "assert.h"
 
 #include <opentracing/noop.h>
 #include <opentracing/tracer.h>
-#include <cassert>
 using namespace opentracing;
 
 static void test_tracer_interface() {
   auto tracer = MakeNoopTracer();
 
   auto span1 = tracer->StartSpan("a");
-  assert(span1);
-  assert(&span1->tracer() == tracer.get());
+  ASSERT(span1);
+  ASSERT(&span1->tracer() == tracer.get());
 
   auto span2 = tracer->StartSpan("b", {ChildOf(&span1->context())});
-  assert(span2);
+  ASSERT(span2);
   span2->SetOperationName("b1");
   span2->SetTag("x", true);
-  assert(span2->BaggageItem("y").empty());
+  ASSERT(span2->BaggageItem("y").empty());
   span2->Log({{"event", "xyz"}, {"abc", 123}});
   span2->Finish();
 }
@@ -27,7 +25,7 @@ static void test_start_span_options() {
 
   // A reference to null a SpanContext is ignored.
   ChildOf(nullptr).Apply(options);
-  assert(options.references.size() == 0);
+  ASSERT(options.references.size() == 0);
 }
 
 int main() {

--- a/test/tracer_test.cpp
+++ b/test/tracer_test.cpp
@@ -1,3 +1,6 @@
+// Make sure assert is defined.
+#undef NDEBUG
+
 #include <opentracing/noop.h>
 #include <opentracing/tracer.h>
 #include <cassert>

--- a/test/util_test.cpp
+++ b/test/util_test.cpp
@@ -1,8 +1,6 @@
-// Make sure assert is defined.
-#undef NDEBUG
+#include "assert.h"
 
 #include <opentracing/util.h>
-#include <cassert>
 #include <cmath>
 #include <cstdlib>  // Work around to https://stackoverflow.com/a/30084734.
 using namespace opentracing;
@@ -16,7 +14,7 @@ static void test_convert_time_point() {
   auto t3 = convert_time_point<SystemClock>(t2);
   auto difference = std::abs(
       std::chrono::duration_cast<std::chrono::microseconds>(t3 - t1).count());
-  assert(difference < 100);
+  ASSERT(difference < 100);
 }
 
 int main() {

--- a/test/util_test.cpp
+++ b/test/util_test.cpp
@@ -1,3 +1,6 @@
+// Make sure assert is defined.
+#undef NDEBUG
+
 #include <opentracing/util.h>
 #include <cassert>
 #include <cmath>

--- a/test/value_test.cpp
+++ b/test/value_test.cpp
@@ -1,3 +1,6 @@
+// Make sure assert is defined.
+#undef NDEBUG
+
 #include <opentracing/value.h>
 #include <cassert>
 using namespace opentracing;

--- a/test/value_test.cpp
+++ b/test/value_test.cpp
@@ -1,30 +1,28 @@
-// Make sure assert is defined.
-#undef NDEBUG
+#include "assert.h"
 
 #include <opentracing/value.h>
-#include <cassert>
 using namespace opentracing;
 
 static void test_implicit_construction() {
   Value v1(123);
-  assert(v1.is<int64_t>());
+  ASSERT(v1.is<int64_t>());
 
   Value v2(123u);
-  assert(v2.is<uint64_t>());
+  ASSERT(v2.is<uint64_t>());
 
   Value v3(true);
-  assert(v3.is<bool>());
+  ASSERT(v3.is<bool>());
 
   Value v4(1.0);
-  assert(v4.is<double>());
+  ASSERT(v4.is<double>());
   Value v5(1.0f);
-  assert(v5.is<double>());
+  ASSERT(v5.is<double>());
 
   Value v6(std::string("abc"));
-  assert(v6.is<std::string>());
+  ASSERT(v6.is<std::string>());
 
   Value v7("abc");
-  assert(v7.is<const char*>());
+  ASSERT(v7.is<const char*>());
 
   Value v8(Values{Value(1), Value(2)});
   (void)v8;


### PR DESCRIPTION
Right now tests aren't run if cmake is built in release mode because asserts are ignored. This PR makes sure `NDEBUG` is undefined in the testing code.