### PR TITLE
Support propagation directly to/from strings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ endif()
 include_directories(include)
 include_directories(SYSTEM 3rd_party/include)
 
-set(SRCS src/propagation.cpp src/noop.cpp src/tracer.cpp)
+set(SRCS src/propagation.cpp src/noop.cpp src/in_memory_stream.cpp src/tracer.cpp)
 add_library(opentracing SHARED ${SRCS})
 target_include_directories(opentracing INTERFACE "$<INSTALL_INTERFACE:include/>")
 set_target_properties(opentracing PROPERTIES VERSION ${OPENTRACING_VERSION_STRING}

--- a/include/opentracing/tracer.h
+++ b/include/opentracing/tracer.h
@@ -106,10 +106,13 @@ class Tracer {
   //
   // Throws only if `writer` does.
   //
-  // If `writer` is an `std::ostream`, then Inject() propagates `sc` as a blob
-  // of binary data.
+  // If `writer` is an `std::ostream` or std::string, then Inject() propagates
+  // `sc` as a blob of binary data.
   virtual expected<void> Inject(const SpanContext& sc,
                                 std::ostream& writer) const = 0;
+
+  virtual expected<void> Inject(const SpanContext& sc,
+                                std::string& writer) const;
 
   virtual expected<void> Inject(const SpanContext& sc,
                                 const TextMapWriter& writer) const = 0;
@@ -132,6 +135,9 @@ class Tracer {
   // Throws only if `reader` does.
   virtual expected<std::unique_ptr<SpanContext>> Extract(
       std::istream& reader) const = 0;
+
+  virtual expected<std::unique_ptr<SpanContext>> Extract(
+      opentracing::string_view reader) const;
 
   virtual expected<std::unique_ptr<SpanContext>> Extract(
       const TextMapReader& reader) const = 0;

--- a/src/in_memory_stream.cpp
+++ b/src/in_memory_stream.cpp
@@ -1,0 +1,15 @@
+#include "in_memory_stream.h"
+
+namespace opentracing {
+BEGIN_OPENTRACING_ABI_NAMESPACE
+InMemoryBuffer::InMemoryBuffer(const char* data, size_t size) {
+  // Data isn't modified so this is safe.
+  auto non_const_data = const_cast<char*>(data);
+  setg(non_const_data, non_const_data, non_const_data + size);
+}
+
+InMemoryStream::InMemoryStream(const char* data, size_t size)
+    : InMemoryBuffer{data, size},
+      std::istream{static_cast<std::streambuf*>(this)} {}
+END_OPENTRACING_ABI_NAMESPACE
+}  // namespace opentracing

--- a/src/in_memory_stream.h
+++ b/src/in_memory_stream.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <opentracing/version.h>
+#include <istream>
+#include <streambuf>
+
+namespace opentracing {
+BEGIN_OPENTRACING_ABI_NAMESPACE
+// Class to allow construction of an istream from constant memory without
+// copying. See https://stackoverflow.com/a/13059195/4447365.
+class InMemoryBuffer : public std::streambuf {
+ public:
+  InMemoryBuffer(const char* data, size_t size);
+};
+
+class InMemoryStream : virtual public InMemoryBuffer, public std::istream {
+ public:
+  InMemoryStream(const char* data, size_t size);
+};
+END_OPENTRACING_ABI_NAMESPACE
+}  // namespace opentracing

--- a/src/in_memory_stream.h
+++ b/src/in_memory_stream.h
@@ -6,13 +6,13 @@
 
 namespace opentracing {
 BEGIN_OPENTRACING_ABI_NAMESPACE
-// Class to allow construction of an istream from constant memory without
-// copying. See https://stackoverflow.com/a/13059195/4447365.
 class InMemoryBuffer : public std::streambuf {
  public:
   InMemoryBuffer(const char* data, size_t size);
 };
 
+// Class to allow construction of an istream from constant memory without
+// copying. See https://stackoverflow.com/a/13059195/4447365.
 class InMemoryStream : virtual public InMemoryBuffer, public std::istream {
  public:
   InMemoryStream(const char* data, size_t size);

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -10,7 +10,7 @@ expected<void> Tracer::Inject(const SpanContext& sc,
   std::ostringstream oss;
   const auto result = Inject(sc, oss);
   if (!result) {
-    return opentracing::make_unexpected(result.error());
+    return result;
   }
   if (!oss) {
     return opentracing::make_unexpected(

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -1,8 +1,37 @@
 #include <opentracing/noop.h>
 #include <opentracing/tracer.h>
+#include <sstream>
+#include "in_memory_stream.h"
 
 namespace opentracing {
 BEGIN_OPENTRACING_ABI_NAMESPACE
+expected<void> Tracer::Inject(const SpanContext& sc,
+                              std::string& writer) const {
+  std::ostringstream oss;
+  const auto result = Inject(sc, oss);
+  if (!result) {
+    return opentracing::make_unexpected(result.error());
+  }
+  if (!oss) {
+    return opentracing::make_unexpected(
+        std::make_error_code(std::errc::io_error));
+  }
+  try {
+    writer = oss.str();
+  } catch (const std::bad_alloc&) {
+    return opentracing::make_unexpected(
+        std::make_error_code(std::errc::not_enough_memory));
+  }
+  return result;
+}
+
+expected<std::unique_ptr<SpanContext>> Tracer::Extract(
+    opentracing::string_view reader) const {
+  // Use InMemoryStream to avoid having to copy the context.
+  InMemoryStream istream{reader.data(), reader.size()};
+  return Extract(istream);
+}
+
 static std::shared_ptr<Tracer>& get_global_tracer() {
   static std::shared_ptr<Tracer> global_tracer = MakeNoopTracer();
   return global_tracer;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,10 @@ add_executable(tracer_test tracer_test.cpp)
 target_link_libraries(tracer_test opentracing) 
 add_test(tracer_test tracer_test)
 
+add_executable(in_memory_stream_test in_memory_stream_test.cpp)
+target_link_libraries(in_memory_stream_test opentracing) 
+add_test(in_memory_stream_test in_memory_stream_test)
+
 add_executable(string_view_test string_view_test.cpp)
 add_test(string_view_test string_view_test)
 

--- a/test/in_memory_stream_test.cpp
+++ b/test/in_memory_stream_test.cpp
@@ -1,0 +1,30 @@
+// Make sure assert is defined.
+#undef NDEBUG
+
+#include "../src/in_memory_stream.h"
+#include <opentracing/string_view.h>
+#include <cassert>
+using namespace opentracing;
+
+static void test_empty_stream() {
+  InMemoryStream stream{nullptr, 0};
+  std::string s;
+  stream >> s;
+  assert(s.empty());
+  assert(stream.eof());
+}
+
+static void test_read_from_nonempty_stream() {
+  string_view data = "123";
+  InMemoryStream stream{data.data(), data.size()};
+  int x;
+  stream >> x;
+  assert(x == 123);
+  assert(stream.eof());
+}
+
+int main() {
+  test_empty_stream();
+  test_read_from_nonempty_stream();
+  return 0;
+}


### PR DESCRIPTION
Adds functions to support propagation directly to/from strings so as to allow tracers to use more efficient implementations.

Includes default implementations for the binary string Inject/Extract functions that use `iostream`'s so that tracers aren't required to provide implementations for them.

Addresses efficiency [concerns](https://github.com/envoyproxy/envoy/pull/2017#discussion_r150085606) that came up when instrumenting envoy for OpenTracing.