### PR TITLE
Add operator* for rvalue reference.

### DIFF
--- a/3rd_party/include/opentracing/expected/expected.hpp
+++ b/3rd_party/include/opentracing/expected/expected.hpp
@@ -670,6 +670,12 @@ public:
         return assert( has_value() ), std::move( contained.value() );
     }
 
+    value_type && operator *() &&
+    {
+        return assert( has_value() ), std::move( contained.value() );
+    }
+
+
     constexpr explicit operator bool() const noexcept
     {
         return has_value();


### PR DESCRIPTION
Fixes #64 