### PR TITLE
Fixes https://github.com/opentracing/opentracing-cpp/issues/80

### DIFF
--- a/mocktracer/src/tracer_factory.cpp
+++ b/mocktracer/src/tracer_factory.cpp
@@ -5,6 +5,7 @@
 #include <fstream>
 #include <stdexcept>
 #include <string>
+#include <cctype>
 
 namespace opentracing {
 BEGIN_OPENTRACING_ABI_NAMESPACE

--- a/src/dynamic_load.cpp
+++ b/src/dynamic_load.cpp
@@ -1,4 +1,3 @@
-#include <dlfcn.h>
 #include <opentracing/dynamic_load.h>
 #include <opentracing/version.h>
 


### PR DESCRIPTION
To build OpenTracing on Windows, remove unused dlfcn.h and add cctype header.