### PR TITLE
Make mocktracer JSON consistent

### DIFF
--- a/mocktracer/include/opentracing/mocktracer/recorder.h
+++ b/mocktracer/include/opentracing/mocktracer/recorder.h
@@ -2,8 +2,10 @@
 #define OPENTRACING_MOCKTRACER_RECORDER_H
 
 #include <opentracing/tracer.h>
+
 #include <cstdint>
 #include <iosfwd>
+#include <map>
 
 namespace opentracing {
 BEGIN_OPENTRACING_ABI_NAMESPACE
@@ -11,7 +13,7 @@ namespace mocktracer {
 struct SpanContextData {
   uint64_t trace_id;
   uint64_t span_id;
-  std::unordered_map<std::string, std::string> baggage;
+  std::map<std::string, std::string> baggage;
 };
 
 inline bool operator==(const SpanContextData& lhs, const SpanContextData& rhs) {
@@ -49,7 +51,7 @@ struct SpanData {
   std::string operation_name;
   SystemTime start_timestamp;
   SteadyClock::duration duration;
-  std::unordered_map<std::string, Value> tags;
+  std::map<std::string, Value> tags;
   std::vector<LogRecord> logs;
 };
 

--- a/mocktracer/include/opentracing/mocktracer/tracer.h
+++ b/mocktracer/include/opentracing/mocktracer/tracer.h
@@ -3,9 +3,9 @@
 
 #include <opentracing/mocktracer/recorder.h>
 #include <opentracing/tracer.h>
+#include <map>
 #include <memory>
 #include <mutex>
-#include <unordered_map>
 
 namespace opentracing {
 BEGIN_OPENTRACING_ABI_NAMESPACE

--- a/mocktracer/src/mock_span.cpp
+++ b/mocktracer/src/mock_span.cpp
@@ -38,7 +38,7 @@ static std::tuple<SystemTime, SteadyTime> ComputeStartTimestamps(
 
 static bool SetSpanReference(
     const std::pair<SpanReferenceType, const SpanContext*>& reference,
-    std::unordered_map<std::string, std::string>& baggage,
+    std::map<std::string, std::string>& baggage,
     SpanReferenceData& reference_data) {
   reference_data.reference_type = reference.first;
   if (reference.second == nullptr) {

--- a/mocktracer/test/json_test.cpp
+++ b/mocktracer/test/json_test.cpp
@@ -39,8 +39,8 @@ TEST_CASE("json") {
       		"trace_id": "000000000000007b",
       		"span_id": "00000000000001c8",
       		"baggage": {
-      			"b2": "v2",
-      			"b1": "v1"
+      			"b1": "v1",
+      			"b2": "v2"
       		}
       	},
       	"references": [{
@@ -52,8 +52,8 @@ TEST_CASE("json") {
       	"start_timestamp": 183600000000,
       	"duration": 92,
       	"tags": {
-      		"t2": "cat",
-      		"t1": 123
+      		"t1": 123,
+      		"t2": "cat"
       	},
       	"logs": [{
       		"timestamp": 183600000000,

--- a/mocktracer/test/tracer_test.cpp
+++ b/mocktracer/test/tracer_test.cpp
@@ -32,8 +32,7 @@ TEST_CASE("tracer") {
     }
     auto span = recorder->top();
     CHECK(span.operation_name == "a");
-    std::unordered_map<std::string, Value> expected_tags = {{"abc", 123},
-                                                            {"xyz", true}};
+    std::map<std::string, Value> expected_tags = {{"abc", 123}, {"xyz", true}};
     CHECK(span.tags == expected_tags);
   }
 
@@ -168,7 +167,7 @@ TEST_CASE("tracer") {
     CHECK(span);
     span->SetTag("abc", 123);
     span->Finish();
-    std::unordered_map<std::string, Value> expected_tags = {{"abc", 123}};
+    std::map<std::string, Value> expected_tags = {{"abc", 123}};
     CHECK(recorder->top().tags == expected_tags);
   }
 }


### PR DESCRIPTION
This PR replaces `unordered_map` with `map` so that the JSON representation for the mocktracer 's spans will be consistent.

See https://github.com/opentracing/opentracing-cpp/issues/85#issuecomment-396086818