### PR TITLE
Include forgotten <memory> header file.

### DIFF
--- a/include/opentracing/span.h
+++ b/include/opentracing/span.h
@@ -7,6 +7,7 @@
 #include <opentracing/version.h>
 #include <chrono>
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
I was trying to use `span.h` file (compiling lightstep) and ran into the following error message:

      /usr/local/include/opentracing/span.h:33:16: error: ‘unique_ptr’ in namespace ‘std’ does not name a template type
         virtual std::unique_ptr<SpanContext> Clone() const noexcept = 0;
                      ^~~~~~~~~~
      /usr/local/include/opentracing/span.h:33:11: note: ‘std::unique_ptr’ is defined in header ‘<memory>’; did you forget to ‘#include <memory>’?

This PR adds the suggested '#include <memory>' to span.h.