### PR TITLE
Add IsGlobalTracerRegistered to Tracer

### DIFF
--- a/include/opentracing/tracer.h
+++ b/include/opentracing/tracer.h
@@ -161,6 +161,9 @@ class OPENTRACING_API Tracer {
   // former global tracer value.
   static std::shared_ptr<Tracer> InitGlobal(
       std::shared_ptr<Tracer> tracer) noexcept;
+
+  // Indicates if a global tracer instance has been set.
+  static bool IsGlobalTracerRegistered() noexcept;
 };
 
 // StartTimestamp is a StartSpanOption that sets an explicit start timestamp for

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -8,6 +8,11 @@ static std::shared_ptr<Tracer>& get_global_tracer() {
   return global_tracer;
 }
 
+static std::atomic<bool>& get_is_global_tracer_registered() {
+  static std::atomic<bool> is_global_tracer_registered{false};;
+  return is_global_tracer_registered;
+}
+
 std::shared_ptr<Tracer> Tracer::Global() noexcept {
   return get_global_tracer();
 }
@@ -15,7 +20,12 @@ std::shared_ptr<Tracer> Tracer::Global() noexcept {
 std::shared_ptr<Tracer> Tracer::InitGlobal(
     std::shared_ptr<Tracer> tracer) noexcept {
   get_global_tracer().swap(tracer);
+  get_is_global_tracer_registered().store(true);
   return tracer;
+}
+
+bool Tracer::IsGlobalTracerRegistered() noexcept {
+  return get_is_global_tracer_registered().load();
 }
 END_OPENTRACING_ABI_NAMESPACE
 }  // namespace opentracing

--- a/src/tracer.cpp
+++ b/src/tracer.cpp
@@ -1,8 +1,11 @@
 #include <opentracing/noop.h>
 #include <opentracing/tracer.h>
+#include <mutex>
 
 namespace opentracing {
 BEGIN_OPENTRACING_ABI_NAMESPACE
+static std::mutex global_tracer_mutex_;
+
 static std::shared_ptr<Tracer>& get_global_tracer() {
   static std::shared_ptr<Tracer> global_tracer = MakeNoopTracer();
   return global_tracer;
@@ -19,6 +22,7 @@ std::shared_ptr<Tracer> Tracer::Global() noexcept {
 
 std::shared_ptr<Tracer> Tracer::InitGlobal(
     std::shared_ptr<Tracer> tracer) noexcept {
+  std::lock_guard<std::mutex> lock_guard{global_tracer_mutex_};
   get_global_tracer().swap(tracer);
   get_is_global_tracer_registered().store(true);
   return tracer;


### PR DESCRIPTION
Adds support for knowing if a global tracer has been registered via a global variable including tests.

Issue first reported here: https://github.com/opentracing/opentracing-python/pull/109

This change has been accepted into C#, Java and Go and there are pending reviews for Python and NodeJS.