### PR TITLE
Fix error handling for dynamic loading.

### DIFF
--- a/ci/setup_linux_environment.sh
+++ b/ci/setup_linux_environment.sh
@@ -8,3 +8,8 @@ sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/bazel.list" \
     -o Dir::Etc::sourceparts="-" \
     -o APT::Get::List-Cleanup="0"
 sudo apt-get install openjdk-8-jdk bazel
+sudo apt-get install software-properties-common
+
+sudo add-apt-repository ppa:george-edison55/cmake-3.x
+sudo apt-get update
+sudo apt-get install cmake

--- a/ci/setup_linux_environment.sh
+++ b/ci/setup_linux_environment.sh
@@ -10,6 +10,6 @@ sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/bazel.list" \
 sudo apt-get install openjdk-8-jdk bazel
 sudo apt-get install software-properties-common
 
-sudo add-apt-repository ppa:george-edison55/cmake-3.x
+sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
 sudo apt-get update
 sudo apt-get install cmake

--- a/src/dynamic_load_unix.cpp
+++ b/src/dynamic_load_unix.cpp
@@ -74,7 +74,7 @@ DynamicallyLoadTracingLibrary(const char* shared_library,
     if (error_message.empty()) {
       error_message = error_code.message();
     }
-    return make_unexpected(error_code);
+    return make_unexpected(dynamic_load_failure_error);
   }
 
   if (tracer_factory == nullptr) {


### PR DESCRIPTION
Fixes the case where a dynamically loaded library returns an error code that references an address that gets dl-unloaded.

See https://github.com/envoyproxy/envoy/issues/5481#issuecomment-451667807

cc @OOberon00