### PR TITLE
Overload convert_time_point for equal clocks

### DIFF
--- a/include/opentracing/util.h
+++ b/include/opentracing/util.h
@@ -36,6 +36,13 @@ class option_wrapper {
   const T *ptr_;
 };
 
+template <class SameClock, class Duration>
+typename SameClock::time_point convert_time_point(
+    std::chrono::time_point<SameClock, Duration> from_time_point) {
+  return std::chrono::duration_cast<typename ToClock::duration>(
+      from_time_point);
+}
+ 
 // Support conversion between time_points from different clocks. There's no
 // standard way to get the difference in epochs between clocks, so this uses
 // an approximation suggested by Howard Hinnant.

--- a/include/opentracing/util.h
+++ b/include/opentracing/util.h
@@ -39,7 +39,7 @@ class option_wrapper {
 template <class SameClock, class Duration>
 typename SameClock::time_point convert_time_point(
     std::chrono::time_point<SameClock, Duration> from_time_point) {
-  return std::chrono::duration_cast<typename ToClock::duration>(
+  return std::chrono::duration_cast<typename SameClock::duration>(
       from_time_point);
 }
  


### PR DESCRIPTION
This is faster and more precise if `convert_time_point` is called with equal ToClock and FromClock.