### PR TITLE
Fix comment for Tracer::StartSpan

### DIFF
--- a/include/opentracing/tracer.h
+++ b/include/opentracing/tracer.h
@@ -84,7 +84,7 @@ class OPENTRACING_API Tracer {
   //     auto span = tracer.StartSpan(
   //         "GetFeed",
   //         {opentracing::ChildOf(&parentSpan.context()),
-  //         opentracing::Tag{"user_agent", loggedReq.UserAgent},
+  //         opentracing::SetTag{"user_agent", loggedReq.UserAgent},
   //         opentracing::StartTimestamp(loggedReq.timestamp())})
   //
   // If StartSpan is called after Close, it leaves the Tracer in a valid


### PR DESCRIPTION
Beside the comment above `class SetTag`, the comment changed in this PR is the only documentation on how to tag a span at creation time.