### PR TITLE
Repair mojibake in expected.hpp

### DIFF
--- a/3rd_party/include/opentracing/expected/expected.hpp
+++ b/3rd_party/include/opentracing/expected/expected.hpp
@@ -778,13 +778,13 @@ public:
 //  expected<decltype(func(declval<T>())),E> map(F&& func) ;
 
 //  template <typename F>
-//  ’see below’ bind(F&& func);
+//  'see below' bind(F&& func);
 
 //  template <typename F>
 //  expected<T,E> catch_error(F&& f);
 
 //  template <typename F>
-//  ’see below’ then(F&& func);
+//  'see below' then(F&& func);
 
 private:
     bool has_value_;
@@ -955,9 +955,9 @@ public:
         return ! has_value() && std::is_base_of< Ex, decltype( get_unexpected().value() ) >::value;
     }
 
-//  template constexpr ’see below’ unwrap() const&;
+//  template constexpr 'see below' unwrap() const&;
 //
-//  template ’see below’ unwrap() &&;
+//  template 'see below' unwrap() &&;
 
     // factories
 
@@ -968,13 +968,13 @@ public:
 //  expected<decltype(func()), E> map(F&& func) ;
 //
 //  template <typename F>
-//  ’see below’ bind(F&& func) ;
+//  'see below' bind(F&& func) ;
 //
 //  template <typename F>
 //  expected<void,E> catch_error(F&& f);
 //
 //  template <typename F>
-//  ’see below’ then(F&& func);
+//  'see below' then(F&& func);
 
 private:
     bool has_value_;


### PR DESCRIPTION
The affected characters herein triggered warnings:

    C:\Dev\vcpkg\buildtrees\opentracing\src\b67575dab0-0250653c81.clean\
        3rd_party\include\opentracing/expected/expected.hpp(1):
    warning C4828: The file contains a character starting at offset 0x4a77
    that is illegal in the current source character set (codepage 65001).