### PR TITLE
Enable testing on ppc64le architecture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ matrix:
     - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
   - os: linux
     arch: ppc64le
+    dist: xenial
     addons:
       apt:
         sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
     - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
   - os: linux
     arch: ppc64le
-    dist: xenial
     addons:
       apt:
         sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ dist: xenial
 matrix:
   include:
   - os: osx
-    osx_image: xcode9
+    osx_image: xcode12.2
     env:
     - MATRIX_EVAL="CC=clang && CXX=clang++"
   - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,17 @@ matrix:
     env:
     - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
   - os: linux
+    arch: ppc64le
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-6
+        - cmake
+    env:
+    - MATRIX_EVAL="CC=gcc-6 && CXX=g++-6"
+  - os: linux
     addons:
       apt:
         sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: cpp
 sudo: true
-dist: trusty
+dist: xenial
 matrix:
   include:
   - os: osx

--- a/ci/setup_linux_environment.sh
+++ b/ci/setup_linux_environment.sh
@@ -5,12 +5,12 @@ set -e
 ARCH=`arch`
 
 if [[ "$ARCH" = "ppc64le" ]]; then
-apt install gnupg2 apt-transport-https -y
+sudo apt install gnupg2 apt-transport-https -y
 echo "deb https://oplab9.parqtec.unicamp.br/pub/repository/debian/ ./" | sudo tee /etc/apt/sources.list.d/bazel_ppc64le.list
-curl --silent  https://oplab9.parqtec.unicamp.br/pub/key/openpower-gpgkey-public.asc  -o openpower-gpgkey-public.asc
-apt-key add openpower-gpgkey-public.asc
-rm -f openpower-gpgkey-public.asc 
-apt update	
+curl --silent  https://oplab9.parqtec.unicamp.br/pub/key/openpower-gpgkey-public.asc  -o /tmp/openpower-gpgkey-public.asc
+sudo apt-key add /tmp/openpower-gpgkey-public.asc
+sudo rm -f /tmp/openpower-gpgkey-public.asc 
+sudo apt update	
 
 else
 

--- a/ci/setup_linux_environment.sh
+++ b/ci/setup_linux_environment.sh
@@ -2,14 +2,27 @@
 
 set -e
 
+ARCH=`arch`
+
+if [[ "$ARCH" = "ppc64le" ]]; then
+apt install gnupg2 apt-transport-https -y
+echo "deb https://oplab9.parqtec.unicamp.br/pub/repository/debian/ ./" | sudo tee /etc/apt/sources.list.d/bazel_ppc64le.list
+curl --silent  https://oplab9.parqtec.unicamp.br/pub/key/openpower-gpgkey-public.asc  -o openpower-gpgkey-public.asc
+apt-key add openpower-gpgkey-public.asc
+rm -f openpower-gpgkey-public.asc 
+apt update	
+
+else
+
 echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
 curl --silent https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
 sudo apt-get update -o Dir::Etc::sourcelist="sources.list.d/bazel.list" \
-    -o Dir::Etc::sourceparts="-" \
-    -o APT::Get::List-Cleanup="0"
-sudo apt-get install openjdk-8-jdk bazel
-sudo apt-get install software-properties-common
+-o Dir::Etc::sourceparts="-" \
+-o APT::Get::List-Cleanup="0"
 
-sudo add-apt-repository ppa:george-edison55/cmake-3.x -y
+fi
+
 sudo apt-get update
-sudo apt-get install cmake
+sudo apt-get install openjdk-8-jdk bazel -y
+sudo apt-get install software-properties-common -y
+sudo apt-get install cmake -y


### PR DESCRIPTION
This PR Fixes #135 

This PR enables opentracing-cpp on ppc64le architecture
and CI/CD build and tests ( if any ) are triggered via travis.yml