### PR TITLE
Fix FTBFS with glibc 2.34

### DIFF
--- a/3rd_party/include/opentracing/catch2/catch.hpp
+++ b/3rd_party/include/opentracing/catch2/catch.hpp
@@ -6462,7 +6462,7 @@ namespace Catch {
         static bool isSet;
         static struct sigaction oldSigActions[];// [sizeof(signalDefs) / sizeof(SignalDefs)];
         static stack_t oldSigStack;
-        static char altStackMem[];
+        static char *altStackMem;
 
         static void handleSignal( int sig );
 
@@ -6594,6 +6594,7 @@ namespace Catch {
     }
 
     FatalConditionHandler::FatalConditionHandler() {
+        altStackMem = new(char[SIGSTKSZ]);
         isSet = true;
         stack_t sigStack;
         sigStack.ss_sp = altStackMem;
@@ -6610,6 +6611,7 @@ namespace Catch {
     }
 
     FatalConditionHandler::~FatalConditionHandler() {
+        delete[] altStackMem;
         reset();
     }
 
@@ -6628,7 +6630,7 @@ namespace Catch {
     bool FatalConditionHandler::isSet = false;
     struct sigaction FatalConditionHandler::oldSigActions[sizeof(signalDefs)/sizeof(SignalDefs)] = {};
     stack_t FatalConditionHandler::oldSigStack = {};
-    char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
+    char *FatalConditionHandler::altStackMem;
 
 } // namespace Catch
 


### PR DESCRIPTION
Building with glibc 2.34 leads to a compilation error because `SIGSTKSZ`
is not a constant anymore.  From glibc's NEWS file:

```
  * Add _SC_MINSIGSTKSZ and _SC_SIGSTKSZ.  When _SC_SIGSTKSZ_SOURCE or
     _GNU_SOURCE are defined, MINSIGSTKSZ and SIGSTKSZ are no longer
     constant on Linux.  MINSIGSTKSZ is redefined to sysconf(_SC_MINSIGSTKSZ)
     and SIGSTKSZ is redefined to sysconf (_SC_SIGSTKSZ).
```

Here's the error:

```
  In file included from /usr/include/signal.h:328,
                   from /<<PKGBUILDDIR>>/3rd_party/include/opentracing/catch2/catch.hpp:6456,
                   from /<<PKGBUILDDIR>>/test/string_view_test.cpp:5:
  /<<PKGBUILDDIR>>/3rd_party/include/opentracing/catch2/catch.hpp:6631:45: error: size of array ‘altStackMem’ is not an integral constant-expression
   6631 |     char FatalConditionHandler::altStackMem[SIGSTKSZ] = {};
        |                                             ^~~~~~~~

```

The fix here is to dinamically allocate altStackMem.  Tested in Ubuntu
Jammy (22.04).