### PR TITLE
fix: use std::invoke_result instead of std::result_of

### DIFF
--- a/3rd_party/include/opentracing/variant/variant.hpp
+++ b/3rd_party/include/opentracing/variant/variant.hpp
@@ -167,7 +167,11 @@ struct enable_if_type
 template <typename F, typename V, typename Enable = void>
 struct result_of_unary_visit
 {
+#if (defined(__cplusplus) && __cplusplus >= 201703L)
+    using type = typename std::invoke_result<F, V&>::type;
+#else
     using type = typename std::result_of<F(V&)>::type;
+#endif
 };
 
 template <typename F, typename V>
@@ -179,7 +183,11 @@ struct result_of_unary_visit<F, V, typename enable_if_type<typename F::result_ty
 template <typename F, typename V, typename Enable = void>
 struct result_of_binary_visit
 {
+#if (defined(__cplusplus) && __cplusplus >= 201703L)
+    using type = typename std::invoke_result<F, V&, V&>::type;
+#else
     using type = typename std::result_of<F(V&, V&)>::type;
+#endif
 };
 
 template <typename F, typename V>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,14 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/output)
 # ==============================================================================
 # Configure compilers
 
-set(CMAKE_CXX_STANDARD 11)
+include(CheckCXXCompilerFlag)
+CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+if(COMPILER_SUPPORTS_CXX17)
+    set(CMAKE_CXX_STANDARD 17)
+else()
+  set(CMAKE_CXX_STANDARD 11)
+endif()
+
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Weverything \
     -Wno-c++98-compat \


### PR DESCRIPTION
std::result_of was deprecated in c++17 and removed in c++20.

This PR configures the project to use c++17 if the compiler supports it and use std::invoke_result instead of std::result_of.

If the compiler doesn't support c++17, the project is configured to fallback to c++11 and still use std::result_of.