### PR TITLE
Fix build issue with Win32 LoadLibrary when using UNICODE

### DIFF
--- a/src/dynamic_load_windows.cpp
+++ b/src/dynamic_load_windows.cpp
@@ -44,7 +44,7 @@ class DynamicLibraryHandleWindows : public DynamicLibraryHandle {
 
 expected<DynamicTracingLibraryHandle> DynamicallyLoadTracingLibrary(
     const char* shared_library, std::string& error_message) noexcept try {
-  const auto handle = LoadLibrary(shared_library);
+  const auto handle = LoadLibraryA(shared_library);
   if (handle == nullptr) {
     error_message = "An error occurred: " + GetLastErrorAsString();
     return make_unexpected(dynamic_load_failure_error);


### PR DESCRIPTION
Per the *UTF-8 Everywhere Manifesto*, it's best to not rely on the legacy ANSI .vs UNICODE macros for Win32 functions that take strings. Since you explicitly use an ANSI string for the call to ``LoadLibrary`` you should explicitly use the ``LoadLibraryA`` method.

> This causes problems when trying to build your library using vcpkg manager when the setup adds the recommended UNICODE _UNICODE defines.
